### PR TITLE
Small renamings in generate_bids_dataset

### DIFF
--- a/bep032tools/generator/BEP032Generator.py
+++ b/bep032tools/generator/BEP032Generator.py
@@ -306,10 +306,15 @@ class BEP032Data:
         Create a bids dataset from a csv file given in argument
         This file must contain a header row specifying the provided data. Accepted titles are
         defined in the BEP.
+        The general principle for this file is that each line will yield one data file in the outbut BIDS dataset.
         Essential information of the following attributes needs to be present.
         Essential columns are 'sub_id' and 'ses_id'.
-        Optional columns are 'runs', 'tasks' and 'data_file' (only single file per sub_id, ses_id
-        combination supported). 'data_file' needs to be a valid path to a nix or nwb file.
+        Optional columns are 'runs', 'tasks' and 'data_source' (only single file per sub_id, ses_id
+        combination supported).
+        'data_source' can be: i) an input file (in any raw data format) that needs to be converted to the BIDS-supported
+        file formats, ii) an input directory where several raw data files are present that need to be combined and
+        converted to a single file in a BIDS-supported format, iii) a file already in a BIDS-supported format that 
+        will be copied or linked into the BIDS dataset.
 
         Parameters
         ----------
@@ -327,17 +332,17 @@ class BEP032Data:
         if not os.path.isdir(pathToDir):
             os.makedirs(pathToDir)
 
-        for session_kwargs in df.to_dict('index').values():
+        for data_kwargs in df.to_dict('index').values():
             if organize_data:
-                data_file = session_kwargs.pop('data_file')
-            session = cls(**session_kwargs)
-            session.basedir = pathToDir
-            session.generate_directory_structure()
+                data_source = data_kwargs.pop('data_source')
+            data_instance = cls(**data_kwargs)
+            data_instance.basedir = pathToDir
+            data_instance.generate_directory_structure()
             if organize_data:
-                session.register_data_files([data_file])
-                session.organize_data_files(mode='copy')
+                data_instance.register_data_files([data_file])
+                data_instance.organize_data_files(mode='copy')
             try:
-                session.generate_all_metadata_files()
+                data_instance.generate_all_metadata_files()
             except NotImplementedError:
                 pass
 

--- a/bep032tools/generator/BEP032Generator.py
+++ b/bep032tools/generator/BEP032Generator.py
@@ -30,7 +30,7 @@ METADATA_LEVEL_BY_NAME = {build_rule_regexp(v)[0]: k for k, values in METADATA_L
 # TODO: These can be extracted from the BEP032Data init definition. Check out the
 # function inspection options
 ESSENTIAL_CSV_COLUMNS = ['sub_id', 'ses_id']
-OPTIONAL_CSV_COLUMNS = ['tasks', 'runs', 'data_file']
+OPTIONAL_CSV_COLUMNS = ['tasks', 'runs', 'data_source']
 
 
 class BEP032Data:
@@ -41,7 +41,7 @@ class BEP032Data:
     The BEP032Data object can track multiple realizations of `split`, `run`, `task` but only a
     single realization of `session` and `subject`, i.e. to represent multiple `session` folders,
     multiple BEP032Data objects are required. To include multiple realizations of tasks
-    or runs, call the `register_data_files` method for each set of parameters separately.
+    or runs, call the `register_data_sources` method for each set of parameters separately.
 
     Parameters
     ----------
@@ -79,9 +79,12 @@ class BEP032Data:
         self.filename_stem = None
         self._basedir = None
 
-    def register_data_files(self, *files, task=None, run=None, autoconvert=None):
+    def register_data_sources(self, *files, task=None, run=None, autoconvert=None):
         """
-        Gather all the info about the data files that will be added to the BIDS data structure.
+        Gather all the info about the input data sources (files or directories) that will be
+        yield an output data file in the BIDS data structure.
+
+        TODO later: rename the files variable into sources and adapt the docstring
 
         Parameters
         ----------
@@ -198,7 +201,7 @@ class BEP032Data:
 
     def organize_data_files(self, mode='link'):
         """
-        Add all the data files for which info has been gathered in register_data_files to the BIDS data structure
+        Add all the data files for which info has been gathered in register_data_sources to the BIDS data structure
         
         Parameters
         ----------
@@ -327,7 +330,7 @@ class BEP032Data:
         df = extract_structure_from_csv(csv_file)
         df = df[ESSENTIAL_CSV_COLUMNS]
 
-        organize_data = 'data_file' in df
+        organize_data = 'data_source' in df
 
         if not os.path.isdir(pathToDir):
             os.makedirs(pathToDir)
@@ -339,7 +342,7 @@ class BEP032Data:
             data_instance.basedir = pathToDir
             data_instance.generate_directory_structure()
             if organize_data:
-                data_instance.register_data_files([data_file])
+                data_instance.register_data_sources([data_source])
                 data_instance.organize_data_files(mode='copy')
             try:
                 data_instance.generate_all_metadata_files()

--- a/bep032tools/generator/tests/test_BEP032Generator.py
+++ b/bep032tools/generator/tests/test_BEP032Generator.py
@@ -63,7 +63,7 @@ class Test_BEP032Data_ece(unittest.TestCase):
 
     def test_data_files(self):
         self.bep032tools_data.generate_directory_structure()
-        self.bep032tools_data.register_data_files(*self.test_data_files)
+        self.bep032tools_data.register_data_sources(*self.test_data_files)
         self.bep032tools_data.organize_data_files()
 
         session_folder = self.bep032tools_data.get_data_folder()
@@ -79,7 +79,7 @@ class Test_BEP032Data_ece(unittest.TestCase):
 
         for format in ['nix', 'nwb']:
             # testing conversion to nix
-            self.bep032tools_data.register_data_files(self.ascii_data_filename, autoconvert=format)
+            self.bep032tools_data.register_data_sources(self.ascii_data_filename, autoconvert=format)
             self.bep032tools_data.organize_data_files()
 
             observed_files = list(self.bep032tools_data.get_data_folder().glob(f'*.{format}'))
@@ -94,8 +94,8 @@ class Test_BEP032Data_ece(unittest.TestCase):
         tasks = ['task1', 'task2']
         for run in runs:
             for task in tasks:
-                self.bep032tools_data.register_data_files(*nix_files,
-                                                   run=run, task=task)
+                self.bep032tools_data.register_data_sources(*nix_files,
+                                                            run=run, task=task)
 
         self.bep032tools_data.organize_data_files()
 
@@ -128,9 +128,9 @@ class Test_BEP032Data_ece(unittest.TestCase):
         run = 'run1'
         task = 'task1'
 
-        self.bep032tools_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032tools_data.register_data_sources(*nix_files, run=run, task=task)
         # register more data files in a second step
-        self.bep032tools_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032tools_data.register_data_sources(*nix_files, run=run, task=task)
 
         self.bep032tools_data.organize_data_files()
 
@@ -218,7 +218,7 @@ class Test_BEP032Data_ice(unittest.TestCase):
 
     def test_data_files(self):
         self.bep032tools_data.generate_directory_structure()
-        self.bep032tools_data.register_data_files(*self.test_data_files)
+        self.bep032tools_data.register_data_sources(*self.test_data_files)
         self.bep032tools_data.organize_data_files()
 
         session_folder = self.bep032tools_data.get_data_folder()
@@ -234,7 +234,7 @@ class Test_BEP032Data_ice(unittest.TestCase):
 
         for format in ['nix', 'nwb']:
             # testing conversion to nix
-            self.bep032tools_data.register_data_files(self.ascii_data_filename, autoconvert=format)
+            self.bep032tools_data.register_data_sources(self.ascii_data_filename, autoconvert=format)
             self.bep032tools_data.organize_data_files()
 
             observed_files = list(self.bep032tools_data.get_data_folder().glob(f'*.{format}'))
@@ -248,8 +248,8 @@ class Test_BEP032Data_ice(unittest.TestCase):
         tasks = ['task1', 'task2']
         for run in runs:
             for task in tasks:
-                self.bep032tools_data.register_data_files(*nix_files,
-                                                          run=run, task=task)
+                self.bep032tools_data.register_data_sources(*nix_files,
+                                                            run=run, task=task)
 
         self.bep032tools_data.organize_data_files()
 
@@ -282,9 +282,9 @@ class Test_BEP032Data_ice(unittest.TestCase):
         run = 'run1'
         task = 'task1'
 
-        self.bep032tools_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032tools_data.register_data_sources(*nix_files, run=run, task=task)
         # register more data files in a second step
-        self.bep032tools_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032tools_data.register_data_sources(*nix_files, run=run, task=task)
 
         self.bep032tools_data.organize_data_files()
 

--- a/bep032tools/generator/tests/test_BEP032Generator.py
+++ b/bep032tools/generator/tests/test_BEP032Generator.py
@@ -94,8 +94,7 @@ class Test_BEP032Data_ece(unittest.TestCase):
         tasks = ['task1', 'task2']
         for run in runs:
             for task in tasks:
-                self.bep032tools_data.register_data_sources(*nix_files,
-                                                            run=run, task=task)
+                self.bep032tools_data.register_data_sources(*nix_files, run=run, task=task)
 
         self.bep032tools_data.organize_data_files()
 

--- a/bep032tools/generator/tests/test_BEP032Templater.py
+++ b/bep032tools/generator/tests/test_BEP032Templater.py
@@ -53,7 +53,7 @@ class Test_BEP032TemplateData(unittest.TestCase):
 
     def test_data_files(self):
         self.bep032_data.generate_directory_structure()
-        self.bep032_data.register_data_files(*self.test_data_files)
+        self.bep032_data.register_data_sources(*self.test_data_files)
         self.bep032_data.organize_data_files()
 
         session_folder = self.bep032_data.get_data_folder()
@@ -71,8 +71,8 @@ class Test_BEP032TemplateData(unittest.TestCase):
         tasks = ['task1', 'task2']
         for run in runs:
             for task in tasks:
-                self.bep032_data.register_data_files(*nix_files,
-                                                   run=run, task=task)
+                self.bep032_data.register_data_sources(*nix_files,
+                                                       run=run, task=task)
 
         self.bep032_data.organize_data_files()
 
@@ -105,9 +105,9 @@ class Test_BEP032TemplateData(unittest.TestCase):
         run = 'run1'
         task = 'task1'
 
-        self.bep032_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032_data.register_data_sources(*nix_files, run=run, task=task)
         # register more data files in a second step
-        self.bep032_data.register_data_files(*nix_files, run=run, task=task)
+        self.bep032_data.register_data_sources(*nix_files, run=run, task=task)
 
         self.bep032_data.organize_data_files()
 
@@ -122,7 +122,7 @@ class Test_BEP032TemplateData(unittest.TestCase):
     def test_implemented_error_raised(self):
         path = ""
         self.test_generate_structure()
-        self.bep032_data.register_data_files(*self.test_data_files)
+        self.bep032_data.register_data_sources(*self.test_data_files)
         self.bep032_data.organize_data_files()
         self.bep032_data.generate_all_metadata_files()
 


### PR DESCRIPTION
This corresponds to some of what we discussed and decided:
- `generate_bids_dataset`: rename data_file -> data_source, check for consistency 
- remove `session`, use `data_instance` / `ephys_instance`  or similar instead 

Not yet ready for review, coz I need to check for consistency, ahah ;)